### PR TITLE
Use modern applyMiddleware() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Takes a single argument, an optional callback that will be called if an action i
 
 ### Use
 ```js
-import {createStore, applyMiddleware } from "redux";
+import { createStore, applyMiddleware } from "redux";
 import reduxUnhandledAction from "redux-unhandled-action";
 import reducer from "./reducer";
 const callback = (action) => console.error(`${action} didn't lead to creation of a new state object`);
-const store = applyMiddleware(reduxUnhandledAction(callback))(createStore);
+const store = createStore(reducer, applyMiddleware(reduxUnhandledAction(callback)));
 ```
 - - -
 


### PR DESCRIPTION
This is easier to read and is supported since Redux 3.1.0.
Sorry about the change below, it appears that GitHub web UI added a line break at the end.
