### PR TITLE
Ignore invalid actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "babel-preset-es2015": "^6.1.18",
     "sinon": "^1.17.2",
     "tape": "^4.2.2"
+  },
+  "dependencies": {
+    "lodash.isplainobject": "^4.0.6"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,14 @@ import isPlainObject from "lodash.isplainobject";
 
 export default function reduxUnhandledAction(callback = defaultErrorHandler) {
     return ({ getState }) => (next) => (action) => {
-        if (isPlainObject(action)) {
-            if (typeof action.type !== 'undefined') {
-                const prevState = getState();
-                const result = next(action);
-                const nextState = getState();
-                if (prevState === nextState) {
-                    callback(action);
-                }
-                return result;
+        if (isPlainObject(action) && typeof action.type !== "undefined") {
+            const prevState = getState();
+            const result = next(action);
+            const nextState = getState();
+            if (prevState === nextState) {
+                callback(action);
             }
+            return result;
         }
         return next(action);
     };

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,19 @@
 import defaultErrorHandler from "./default-error-handler";
+import isPlainObject from "lodash.isplainobject";
 
 export default function reduxUnhandledAction(callback = defaultErrorHandler) {
-	return ({getState}) => (next) => (action) => {
-		const prevState = getState();
-		const result = next(action);
-		const nextState = getState();
-		if (prevState === nextState) {
-			callback(action);
-		}
-		return result;
-	};
-
+    return ({ getState }) => (next) => (action) => {
+        if (isPlainObject(action)) {
+            if (typeof action.type !== 'undefined') {
+                const prevState = getState();
+                const result = next(action);
+                const nextState = getState();
+                if (prevState === nextState) {
+                    callback(action);
+                }
+                return result;
+            }
+        }
+        return next(action);
+    };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -62,3 +62,21 @@ test("should not error when state is properly updated", function(assert) {
 	assert.notOk(consoleError.called, "console error is not logged when a new state is returned");
 	assert.end();
 });
+
+test("should not call callback if action is not a plain object", function(assert) {
+	var action = [];
+	var callbackSpy = sinon.spy();
+	var actionHandler = unhandledAction(callbackSpy)({getState: getState})(spy)(action);
+	assert.equal(callbackSpy.callCount, 0, "callback is not called when action is not a plain object");
+	assert.ok(spy.calledWith(action), "next called with action when action is not a plain object");
+	assert.end();
+});
+
+test("should not call callback if action doesn't have type property", function(assert) {
+	var action = {};
+	var callbackSpy = sinon.spy();
+	var actionHandler = unhandledAction(callbackSpy)({getState: getState})(spy)(action);
+	assert.equal(callbackSpy.callCount, 0, "callback is not called when action doesn't have type property");
+	assert.ok(spy.calledWith(action), "next called with action when action doesn't have type property");
+	assert.end();
+});


### PR DESCRIPTION
added validation check before middleware processing. Actions that are not plain objects or don't have a type property will be ignored and passed to next middleware.
